### PR TITLE
Improve Error Handling & Allow Multiple Interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hyprspace
+.DS_Store

--- a/cli/init.go
+++ b/cli/init.go
@@ -55,6 +55,7 @@ func InitRun(r *cmd.Root, c *cmd.Sub) {
 	new := config.Config{
 		Interface: config.Interface{
 			Name:        args.InterfaceName,
+			ListenPort:  8001,
 			Address:     "10.1.1.1/24",
 			ID:          host.ID().Pretty(),
 			PrivateKey:  string(keyBytes),

--- a/cli/root.go
+++ b/cli/root.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDrake/cli-ng/v2/cmd"
 )
 
+var appVersion string = "develop"
+
 //GlobalFlags contains the flags for commands.
 type GlobalFlags struct {
 	Config string `short:"c" long:"config" desc:"Specify a custom config path."`
@@ -19,15 +21,18 @@ var Root *cmd.Root
 
 func init() {
 	Root = &cmd.Root{
-		Name:  "hyprspace",
-		Short: "Hyprspace Distributed Network",
-		Flags: &GlobalFlags{},
+		Name:    "hyprspace",
+		Short:   "Hyprspace Distributed Network",
+		Version: appVersion,
+		Flags:   &GlobalFlags{},
 	}
+
 	cmd.Register(&cmd.Help)
 	cmd.Register(&Init)
 	cmd.Register(&Up)
 	cmd.Register(&Down)
 	cmd.Register(&Update)
+	cmd.Register(&cmd.Version)
 }
 
 func checkErr(err error) {

--- a/cli/update.go
+++ b/cli/update.go
@@ -14,8 +14,6 @@ import (
 	"github.com/tcnksm/go-latest"
 )
 
-var appVersion string
-
 // Update checks for a new version of the Hyprspace program and updates itself
 // if a newer version is found and the user agrees to update.
 var Update = cmd.Sub{

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,9 @@ type Config struct {
 // Interface defines all of the fields that a local node needs to know about itself!
 type Interface struct {
 	Name        string `yaml:"name"`
-	Address     string `yaml:"address"`
 	ID          string `yaml:"id"`
+	ListenPort  int    `yaml:"listen_port"`
+	Address     string `yaml:"address"`
 	DiscoverKey string `yaml:"discover_key"`
 	PrivateKey  string `yaml:"private_key"`
 }
@@ -31,6 +32,16 @@ func Read(path string) (result Config, err error) {
 	in, err := os.ReadFile(path)
 	if err != nil {
 		return
+	}
+	result = Config{
+		Interface: Interface{
+			Name:        "hs0",
+			ListenPort:  8001,
+			Address:     "10.1.1.1",
+			ID:          "",
+			DiscoverKey: "",
+			PrivateKey:  "",
+		},
 	}
 	err = yaml.Unmarshal(in, &result)
 	return

--- a/p2p/discover.go
+++ b/p2p/discover.go
@@ -18,7 +18,7 @@ func Discover(ctx context.Context, h host.Host, dht *dht.IpfsDHT, rendezvous str
 	var routingDiscovery = discovery.NewRoutingDiscovery(dht)
 	discovery.Advertise(ctx, routingDiscovery, rendezvous)
 
-	ticker := time.NewTicker(time.Second * 1)
+	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
 
 	for {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -18,7 +18,7 @@ import (
 const Protocol = "/hyprspace/0.0.1"
 
 // CreateNode creates an internal Libp2p nodes and returns it and it's DHT Discovery service.
-func CreateNode(ctx context.Context, inputKey string, handler network.StreamHandler) (node host.Host, dhtOut *dht.IpfsDHT, err error) {
+func CreateNode(ctx context.Context, inputKey string, port int, handler network.StreamHandler) (node host.Host, dhtOut *dht.IpfsDHT, err error) {
 	// Unmarshal Private Key
 	privateKey, err := crypto.UnmarshalPrivateKey([]byte(inputKey))
 	if err != nil {
@@ -27,7 +27,7 @@ func CreateNode(ctx context.Context, inputKey string, handler network.StreamHand
 
 	// Create libp2p node
 	node, err = libp2p.New(ctx,
-		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", 8001)),
+		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port)),
 		libp2p.Identity(privateKey),
 	)
 	if err != nil {


### PR DESCRIPTION
This PR fixes #8 by implementing a better recording system for daemon creation logs. It will now properly tell the user when Hyprspace fails to create a daemon. This PR also fixes #9 by allowing users to pick custom ports for interfaces as well as dynamically picking ports when two interfaces are set to listen on the same default port.