### PR TITLE
Switch to DHTClient Mode & Build Smaller Binaries

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -7,6 +7,6 @@ do
     platform_split=(${platform//\// })
     GOOS=${platform_split[0]}
     GOARCH=${platform_split[1]}
-    env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH} .
+    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH} .
 
 done

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDrake/cli-ng/v2 v2.0.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
+	github.com/ipfs/go-datastore v0.4.5
 	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.14.1
 	github.com/libp2p/go-libp2p-core v0.8.5

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -38,10 +39,7 @@ func CreateNode(ctx context.Context, inputKey string, port int, handler network.
 	node.SetStreamHandler(Protocol, handler)
 
 	// Create DHT Subsystem
-	dhtOut, err = dht.New(ctx, node)
-	if err != nil {
-		return
-	}
+	dhtOut = dht.NewDHTClient(ctx, node, datastore.NewMapDatastore())
 
 	// Define Bootstrap Nodes.
 	peers := []string{


### PR DESCRIPTION
Switch to DHT Client mode to reduce networking overhead and remove debugging information from binaries to reduce application size. Should help fix #12.