### PR TITLE
Don't hardcode `ip` binary path

### DIFF
--- a/tun/tun.go
+++ b/tun/tun.go
@@ -46,7 +46,7 @@ func Delete(name string) (err error) {
 }
 
 func ip(args ...string) (err error) {
-	cmd := exec.Command("/sbin/ip", args...)
+	cmd := exec.Command("ip", args...)
 	err = cmd.Run()
 	return
 }


### PR DESCRIPTION
Not all systems install the binary in this path, a correctly configured PATH environment variable should suffice.