### PR TITLE
Added keygen utility to cli

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -40,16 +40,7 @@ func InitRun(r *cmd.Root, c *cmd.Sub) {
 	}
 
 	// Create New Libp2p Node
-	host, err := libp2p.New(context.Background())
-	checkErr(err)
-
-	// Get Node's Private Key
-	keyBytes, err := crypto.MarshalPrivateKey(host.Peerstore().PrivKey(host.ID()))
-	checkErr(err)
-
-	// Generate a random diceware discovery key
-	list, err := diceware.Generate(4)
-	checkErr(err)
+	host := CreateNode()
 
 	// Setup an initial default command.
 	new := config.Config{
@@ -57,9 +48,9 @@ func InitRun(r *cmd.Root, c *cmd.Sub) {
 			Name:        args.InterfaceName,
 			ListenPort:  8001,
 			Address:     "10.1.1.1/24",
-			ID:          host.ID().Pretty(),
-			PrivateKey:  string(keyBytes),
-			DiscoverKey: strings.Join(list, "-"),
+			ID:          GetID(host),
+			PrivateKey:  GetPrivateKey(host),
+			DiscoverKey: GenerateDiscoveryKey(),
 		},
 	}
 

--- a/cli/keygen.go
+++ b/cli/keygen.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDrake/cli-ng/v2/cmd"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/sethvargo/go-diceware/diceware"
+)
+
+// KeyGen saves a node authentication for a Hyprspace Interface to files.
+var KeyGen = cmd.Sub{
+	Name:	"keygen",
+	Alias:	"k",
+	Short:	"Generate authentication keys",
+	Flags:	&KeyGenFlags{},
+	Run:	KeyGenRun,
+}
+
+// KeyGenFlags handles the specific flags for the keygen command.
+type KeyGenFlags struct {
+	OutPath string `short:"k" long:"keygen" desc:"Generate authentication keys"`
+}
+
+// Create New Libp2p Node
+func CreateNode() host.Host {
+	host, err := libp2p.New(context.Background())
+	checkErr(err)
+	return host
+}
+
+// Get a Node's Private Key as a String
+func GetPrivateKey(host host.Host) string {
+	keyBytes, err := crypto.MarshalPrivateKey(host.Peerstore().PrivKey(host.ID()))
+	checkErr(err)
+	return string(keyBytes)
+}
+
+// Get a Node's ID as a String
+func GetID(host host.Host) string {
+	return host.ID().Pretty()
+}
+
+// Generate a random diceware discovery key
+func GenerateDiscoveryKey() string {
+	list, err := diceware.Generate(4)
+	checkErr(err)
+	return strings.Join(list, "-")
+}
+
+// Write Generated Keys to File
+func WriteFile(outPath string, fileName string, content string) {
+	path := fmt.Sprintf("%s/%s", outPath, fileName)
+    err := os.WriteFile(path, []byte(content), 0077)
+    checkErr(err)
+}
+
+// KeyGenRun handles the execution of the node command.
+func KeyGenRun(r *cmd.Root, c *cmd.Sub) {
+
+	outPath := c.Flags.(*KeyGenFlags).OutPath
+	if outPath == "" {
+		outPath = "~/.hyprspace"
+	}
+
+	host := CreateNode()
+	PrivateKey := GetPrivateKey(host)
+	ID := GetID(host)
+	DiscoverKey := GenerateDiscoveryKey()
+
+	err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm)
+	checkErr(err)
+
+	WriteFile(outPath, "key.hyprspace", PrivateKey)
+	WriteFile(outPath, "id.hyprspace", ID)
+	WriteFile(outPath, "discover.hyprspace", DiscoverKey)
+}


### PR DESCRIPTION
Hi thanks for the awesome project.

This is an extension to the cli that mirrors ssh-keygen in that it writes the necessary hyprspace keys to files. (It also writes the  DiscoverKey but that might be overkill and might be removed / moved to adding a flag to print a discover key to stdout). 

By default the keys are written to `~/hyprspace/{key,id,discover}hyprspace`, the command allows overwriting this however.

The specific use case for this is for utilizing this package with a NixOS module similar to how [wireguard](https://nixos.wiki/wiki/WireGuard) is setup currently.

Briefly everything that Nix builds is stored and publicly accessible which for things like keys is always a no no. So this allows extracting the node/authentication step and adding them in later via a secure means.

Also this is the first Go code I have ever written so apologies for any glaring errghs