### PR TITLE
Support Windows, Linux and presumably macOS

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64")
+platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64" "windows/386")
 
 for platform in "${platforms[@]}"
 do
     platform_split=(${platform//\// })
     GOOS=${platform_split[0]}
     GOARCH=${platform_split[1]}
-    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH} .
+    [ $GOOS == "windows" ] && EXT=".exe"
+    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH}${EXT} .
 
 done

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you're running Hyprspace on a Mac you'll need to install `iproute2mac`. If yo
 ```bash
 brew install iproute2mac
 ```
+If you're running Hyprspace on Windows you'll need to install [tap-windows](http://build.openvpn.net/downloads/releases/).
 
 ### Installation
 
@@ -87,6 +88,8 @@ interface on our local machine `hs0` (for hypr-space 0) and `hs1` on our remote 
 but yours could be anything you'd like. 
 
 (Note: if you're using a Mac you'll have to use the interface name `utun[0-9]`. Check which interfaces are already in use by running `ip a` once you've got `iproute2mac` installed.)
+
+(Note: if you're using Windows you'll have to use the interface name as seen in Control Panel. IP address will be set automatically only if you run Hyprspace as Administrator.)
 
 ###### Local Machine
 ```bash

--- a/cli/up.go
+++ b/cli/up.go
@@ -98,7 +98,7 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 
 	fmt.Println("[+] Creating TUN Device")
 	// Create new TUN device
-	iface, err = tun.New(cfg.Interface.Name)
+	iface, err = tun.New(cfg.Interface.Name, cfg.Interface.Address)
 	if err != nil {
 		checkErr(errors.New("interface already in use"))
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
+	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -879,6 +879,10 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
@@ -1042,6 +1046,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190526052359-791d8a0f4d09/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !linux
+// +build !windows,!linux
 
 package tun
 
@@ -11,7 +11,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string, address string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -4,8 +4,10 @@
 package tun
 
 import (
+	"fmt"
+	"os/exec"
+
 	"github.com/songgao/water"
-	"github.com/vishvananda/netlink"
 )
 
 // New creates and returns a new TUN interface for the application.
@@ -22,50 +24,32 @@ func New(name string, address string) (result *water.Interface, err error) {
 
 // SetMTU sets the Maximum Tansmission Unit Size for a
 // Packet on the interface.
-func SetMTU(name string, mtu int) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetMTU(link, mtu)
+func SetMTU(name string, mtu int) (err error) {
+	return ip("link", "set", "dev", name, "mtu", fmt.Sprintf("%d", mtu))
 }
 
 // SetAddress sets the interface's known address and subnet.
-func SetAddress(name string, address string) error {
-	addr, err := netlink.ParseAddr(address)
-	if err != nil {
-		return err
-	}
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.AddrAdd(link, addr)
+func SetAddress(name string, address string) (err error) {
+	return ip("addr", "add", address, "dev", name)
 }
 
 // Up brings up an interface to allow it to start accepting connections.
-func Up(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetUp(link)
+func Up(name string) (err error) {
+	return ip("link", "set", "dev", name, "up")
 }
 
 // Down brings down an interface stopping active connections.
-func Down(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetDown(link)
+func Down(name string) (err error) {
+	return ip("link", "set", "dev", name, "down")
 }
 
 // Delete removes a TUN device from the host.
-func Delete(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkDel(link)
+func Delete(name string) (err error) {
+	return ip("link", "delete", "dev", name)
+}
+
+func ip(args ...string) (err error) {
+	cmd := exec.Command("ip", args...)
+	err = cmd.Run()
+	return
 }

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -4,10 +4,8 @@
 package tun
 
 import (
-	"fmt"
-	"os/exec"
-
 	"github.com/songgao/water"
+	"github.com/vishvananda/netlink"
 )
 
 // New creates and returns a new TUN interface for the application.
@@ -24,32 +22,50 @@ func New(name string, address string) (result *water.Interface, err error) {
 
 // SetMTU sets the Maximum Tansmission Unit Size for a
 // Packet on the interface.
-func SetMTU(name string, mtu int) (err error) {
-	return ip("link", "set", "dev", name, "mtu", fmt.Sprintf("%d", mtu))
+func SetMTU(name string, mtu int) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 // SetAddress sets the interface's known address and subnet.
-func SetAddress(name string, address string) (err error) {
-	return ip("addr", "add", address, "dev", name)
+func SetAddress(name string, address string) error {
+	addr, err := netlink.ParseAddr(address)
+	if err != nil {
+		return err
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.AddrAdd(link, addr)
 }
 
 // Up brings up an interface to allow it to start accepting connections.
-func Up(name string) (err error) {
-	return ip("link", "set", "dev", name, "up")
+func Up(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetUp(link)
 }
 
 // Down brings down an interface stopping active connections.
-func Down(name string) (err error) {
-	return ip("link", "set", "dev", name, "down")
+func Down(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetDown(link)
 }
 
 // Delete removes a TUN device from the host.
-func Delete(name string) (err error) {
-	return ip("link", "delete", "dev", name)
-}
-
-func ip(args ...string) (err error) {
-	cmd := exec.Command("ip", args...)
-	err = cmd.Run()
-	return
+func Delete(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkDel(link)
 }

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package tun
 
 import (
@@ -8,7 +11,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string) (result *water.Interface, err error) {
+func New(name string, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+// +build linux
+
+package tun
+
+import (
+	"github.com/songgao/water"
+	"github.com/vishvananda/netlink"
+)
+
+// New creates and returns a new TUN interface for the application.
+func New(name string) (result *water.Interface, err error) {
+	// Setup TUN Config
+	cfg := water.Config{
+		DeviceType: water.TUN,
+	}
+	cfg.Name = name
+	// Create TUN Interface
+	result, err = water.New(cfg)
+	return
+}
+
+// SetMTU sets the Maximum Tansmission Unit Size for a
+// Packet on the interface.
+func SetMTU(name string, mtu int) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetMTU(link, mtu)
+}
+
+// SetAddress sets the interface's known address and subnet.
+func SetAddress(name string, address string) error {
+	addr, err := netlink.ParseAddr(address)
+	if err != nil {
+		return err
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.AddrAdd(link, addr)
+}
+
+// Up brings up an interface to allow it to start accepting connections.
+func Up(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetUp(link)
+}
+
+// Down brings down an interface stopping active connections.
+func Down(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetDown(link)
+}
+
+// Delete removes a TUN device from the host.
+func Delete(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkDel(link)
+}

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -4,15 +4,15 @@
 package tun
 
 import (
-	"os/exec"
-	"net"
 	"fmt"
+	"net"
+	"os/exec"
 
 	"github.com/songgao/water"
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string, address string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// TUN on Windows requires address and network to be set on device creation stage
 	// We also set network to 0.0.0.0/0 so we able to reach networks behind the node
 	// https://github.com/songgao/water/blob/master/params_windows.go
@@ -23,7 +23,7 @@ func New(name string, address string) (result *water.Interface, err error) {
 	}
 	network := net.IPNet{
 		IP:   ip,
-		Mask: net.IPv4Mask(0,0,0,0),
+		Mask: net.IPv4Mask(0, 0, 0, 0),
 	}
 	// Setup TUN Config
 	cfg := water.Config{

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+// +build windows
+
+package tun
+
+import (
+	"os/exec"
+	"net"
+	"fmt"
+
+	"github.com/songgao/water"
+)
+
+// New creates and returns a new TUN interface for the application.
+func New(name string, address string) (result *water.Interface, err error) {
+	// TUN on Windows requires address and network to be set on device creation stage
+	// We also set network to 0.0.0.0/0 so we able to reach networks behind the node
+	// https://github.com/songgao/water/blob/master/params_windows.go
+	// https://gitlab.com/openconnect/openconnect/-/blob/master/tun-win32.c
+	ip, _, err := net.ParseCIDR(address)
+	if err != nil {
+		return nil, err
+	}
+	network := net.IPNet{
+		IP:   ip,
+		Mask: net.IPv4Mask(0,0,0,0),
+	}
+	// Setup TUN Config
+	cfg := water.Config{
+		DeviceType: water.TUN,
+		PlatformSpecificParams: water.PlatformSpecificParams{
+			ComponentID:   "tap0901",
+			InterfaceName: name,
+			Network:       network.String(),
+		},
+	}
+	// Create TUN Interface
+	result, err = water.New(cfg)
+	return
+}
+
+// SetMTU sets the Maximum Tansmission Unit Size for a
+// Packet on the interface.
+func SetMTU(name string, mtu int) (err error) {
+	return netsh("interface", "ipv4", "set", "subinterface", name, "mtu=", fmt.Sprintf("%d", mtu))
+}
+
+// SetAddress sets the interface's known address and subnet.
+func SetAddress(name string, address string) (err error) {
+	return netsh("interface", "ip", "set", "address", "name=", name, "static", address)
+}
+
+// Up brings up an interface to allow it to start accepting connections.
+func Up(name string) (err error) {
+	return
+}
+
+// Down brings down an interface stopping active connections.
+func Down(name string) (err error) {
+	return
+}
+
+// Delete removes a TUN device from the host.
+func Delete(name string) (err error) {
+	return
+}
+
+func netsh(args ...string) (err error) {
+	cmd := exec.Command("netsh", args...)
+	err = cmd.Run()
+	return
+}


### PR DESCRIPTION
* Add Windows support
  + Integrate the changes from #63 
* Remove the runtime dependency on the `ip` command on Linux systems.
  + Use `github.com/vishvananda/netlink` instead, which calls the kernel directly.
* Support other OSes, so long as the `ip` command is available at runtime.