### PR TITLE
Bump Go version to 1.17

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64")
+platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64" "windows/386")
 
 for platform in "${platforms[@]}"
 do
     platform_split=(${platform//\// })
     GOOS=${platform_split[0]}
     GOARCH=${platform_split[1]}
-    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH} .
+    [ $GOOS == "windows" ] && EXT=".exe"
+    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH}${EXT} .
 
 done

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you're running Hyprspace on a Mac you'll need to install `iproute2mac`. If yo
 ```bash
 brew install iproute2mac
 ```
+If you're running Hyprspace on Windows you'll need to install [tap-windows](http://build.openvpn.net/downloads/releases/).
 
 ### Installation
 
@@ -87,6 +88,8 @@ interface on our local machine `hs0` (for hypr-space 0) and `hs1` on our remote 
 but yours could be anything you'd like. 
 
 (Note: if you're using a Mac you'll have to use the interface name `utun[0-9]`. Check which interfaces are already in use by running `ip a` once you've got `iproute2mac` installed.)
+
+(Note: if you're using Windows you'll have to use the interface name as seen in Control Panel. IP address will be set automatically only if you run Hyprspace as Administrator.)
 
 ###### Local Machine
 ```bash

--- a/cli/up.go
+++ b/cli/up.go
@@ -98,7 +98,7 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 
 	fmt.Println("[+] Creating TUN Device")
 	// Create new TUN device
-	iface, err = tun.New(cfg.Interface.Name)
+	iface, err = tun.New(cfg.Interface.Name, cfg.Interface.Address)
 	if err != nil {
 		checkErr(errors.New("interface already in use"))
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
+	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/hyprspace/hyprspace
 
-go 1.16
+go 1.17
 
 require (
 	github.com/DataDrake/cli-ng/v2 v2.0.2
-	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.14.1
 	github.com/libp2p/go-libp2p-core v0.8.6
 	github.com/libp2p/go-libp2p-kad-dht v0.12.1
@@ -18,7 +16,120 @@ require (
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
-	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/btcsuite/btcd v0.21.0-beta // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cheekybits/genny v1.0.0 // indirect
+	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
+	github.com/flynn/noise v1.0.0 // indirect
+	github.com/francoispqt/gojay v1.2.13 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-version v1.2.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/huin/goupnp v1.0.0 // indirect
+	github.com/ipfs/go-cid v0.0.7 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
+	github.com/ipfs/go-ipns v0.0.2 // indirect
+	github.com/ipfs/go-log v1.0.5 // indirect
+	github.com/ipfs/go-log/v2 v2.1.3 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
+	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/klauspost/compress v1.11.7 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.4 // indirect
+	github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/libp2p/go-addr-util v0.0.2 // indirect
+	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
+	github.com/libp2p/go-cidranger v1.1.0 // indirect
+	github.com/libp2p/go-conn-security-multistream v0.2.1 // indirect
+	github.com/libp2p/go-eventbus v0.2.1 // indirect
+	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
+	github.com/libp2p/go-libp2p-asn-util v0.0.0-20200825225859-85005c6cf052 // indirect
+	github.com/libp2p/go-libp2p-autonat v0.4.2 // indirect
+	github.com/libp2p/go-libp2p-blankhost v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-circuit v0.4.0 // indirect
+	github.com/libp2p/go-libp2p-discovery v0.5.0 // indirect
+	github.com/libp2p/go-libp2p-kbucket v0.4.7 // indirect
+	github.com/libp2p/go-libp2p-mplex v0.4.1 // indirect
+	github.com/libp2p/go-libp2p-nat v0.0.6 // indirect
+	github.com/libp2p/go-libp2p-noise v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.2.7 // indirect
+	github.com/libp2p/go-libp2p-pnet v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-record v0.1.3 // indirect
+	github.com/libp2p/go-libp2p-swarm v0.5.0 // indirect
+	github.com/libp2p/go-libp2p-tls v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.4.6 // indirect
+	github.com/libp2p/go-libp2p-yamux v0.5.4 // indirect
+	github.com/libp2p/go-maddr-filter v0.1.0 // indirect
+	github.com/libp2p/go-mplex v0.3.0 // indirect
+	github.com/libp2p/go-msgio v0.0.6 // indirect
+	github.com/libp2p/go-nat v0.0.5 // indirect
+	github.com/libp2p/go-netroute v0.1.6 // indirect
+	github.com/libp2p/go-openssl v0.0.7 // indirect
+	github.com/libp2p/go-reuseport v0.0.2 // indirect
+	github.com/libp2p/go-reuseport-transport v0.0.5 // indirect
+	github.com/libp2p/go-sockaddr v0.1.1 // indirect
+	github.com/libp2p/go-stream-muxer-multistream v0.3.0 // indirect
+	github.com/libp2p/go-ws-transport v0.4.0 // indirect
+	github.com/libp2p/go-yamux/v2 v2.2.0 // indirect
+	github.com/lucas-clemente/quic-go v0.23.0 // indirect
+	github.com/marten-seemann/qtls-go1-16 v0.1.4 // indirect
+	github.com/marten-seemann/qtls-go1-17 v0.1.0 // indirect
+	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/miekg/dns v1.1.41 // indirect
+	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
+	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-base32 v0.0.3 // indirect
+	github.com/multiformats/go-base36 v0.1.0 // indirect
+	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
+	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
+	github.com/multiformats/go-multiaddr-net v0.2.0 // indirect
+	github.com/multiformats/go-multibase v0.0.3 // indirect
+	github.com/multiformats/go-multihash v0.0.15 // indirect
+	github.com/multiformats/go-multistream v0.2.2 // indirect
+	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.10.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.18.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
+	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.16.0 // indirect
+	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/tools v0.1.1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -879,6 +879,10 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
@@ -1042,6 +1046,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190526052359-791d8a0f4d09/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !linux
+// +build !windows,!linux
 
 package tun
 
@@ -11,7 +11,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string, address string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -4,8 +4,10 @@
 package tun
 
 import (
+	"fmt"
+	"os/exec"
+
 	"github.com/songgao/water"
-	"github.com/vishvananda/netlink"
 )
 
 // New creates and returns a new TUN interface for the application.
@@ -22,50 +24,32 @@ func New(name string, address string) (result *water.Interface, err error) {
 
 // SetMTU sets the Maximum Tansmission Unit Size for a
 // Packet on the interface.
-func SetMTU(name string, mtu int) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetMTU(link, mtu)
+func SetMTU(name string, mtu int) (err error) {
+	return ip("link", "set", "dev", name, "mtu", fmt.Sprintf("%d", mtu))
 }
 
 // SetAddress sets the interface's known address and subnet.
-func SetAddress(name string, address string) error {
-	addr, err := netlink.ParseAddr(address)
-	if err != nil {
-		return err
-	}
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.AddrAdd(link, addr)
+func SetAddress(name string, address string) (err error) {
+	return ip("addr", "add", address, "dev", name)
 }
 
 // Up brings up an interface to allow it to start accepting connections.
-func Up(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetUp(link)
+func Up(name string) (err error) {
+	return ip("link", "set", "dev", name, "up")
 }
 
 // Down brings down an interface stopping active connections.
-func Down(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetDown(link)
+func Down(name string) (err error) {
+	return ip("link", "set", "dev", name, "down")
 }
 
 // Delete removes a TUN device from the host.
-func Delete(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkDel(link)
+func Delete(name string) (err error) {
+	return ip("link", "delete", "dev", name)
+}
+
+func ip(args ...string) (err error) {
+	cmd := exec.Command("ip", args...)
+	err = cmd.Run()
+	return
 }

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -4,10 +4,8 @@
 package tun
 
 import (
-	"fmt"
-	"os/exec"
-
 	"github.com/songgao/water"
+	"github.com/vishvananda/netlink"
 )
 
 // New creates and returns a new TUN interface for the application.
@@ -24,32 +22,50 @@ func New(name string, address string) (result *water.Interface, err error) {
 
 // SetMTU sets the Maximum Tansmission Unit Size for a
 // Packet on the interface.
-func SetMTU(name string, mtu int) (err error) {
-	return ip("link", "set", "dev", name, "mtu", fmt.Sprintf("%d", mtu))
+func SetMTU(name string, mtu int) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 // SetAddress sets the interface's known address and subnet.
-func SetAddress(name string, address string) (err error) {
-	return ip("addr", "add", address, "dev", name)
+func SetAddress(name string, address string) error {
+	addr, err := netlink.ParseAddr(address)
+	if err != nil {
+		return err
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.AddrAdd(link, addr)
 }
 
 // Up brings up an interface to allow it to start accepting connections.
-func Up(name string) (err error) {
-	return ip("link", "set", "dev", name, "up")
+func Up(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetUp(link)
 }
 
 // Down brings down an interface stopping active connections.
-func Down(name string) (err error) {
-	return ip("link", "set", "dev", name, "down")
+func Down(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetDown(link)
 }
 
 // Delete removes a TUN device from the host.
-func Delete(name string) (err error) {
-	return ip("link", "delete", "dev", name)
-}
-
-func ip(args ...string) (err error) {
-	cmd := exec.Command("ip", args...)
-	err = cmd.Run()
-	return
+func Delete(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkDel(link)
 }

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package tun
 
 import (
@@ -8,7 +11,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string) (result *water.Interface, err error) {
+func New(name string, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+// +build linux
+
+package tun
+
+import (
+	"github.com/songgao/water"
+	"github.com/vishvananda/netlink"
+)
+
+// New creates and returns a new TUN interface for the application.
+func New(name string) (result *water.Interface, err error) {
+	// Setup TUN Config
+	cfg := water.Config{
+		DeviceType: water.TUN,
+	}
+	cfg.Name = name
+	// Create TUN Interface
+	result, err = water.New(cfg)
+	return
+}
+
+// SetMTU sets the Maximum Tansmission Unit Size for a
+// Packet on the interface.
+func SetMTU(name string, mtu int) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetMTU(link, mtu)
+}
+
+// SetAddress sets the interface's known address and subnet.
+func SetAddress(name string, address string) error {
+	addr, err := netlink.ParseAddr(address)
+	if err != nil {
+		return err
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.AddrAdd(link, addr)
+}
+
+// Up brings up an interface to allow it to start accepting connections.
+func Up(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetUp(link)
+}
+
+// Down brings down an interface stopping active connections.
+func Down(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetDown(link)
+}
+
+// Delete removes a TUN device from the host.
+func Delete(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkDel(link)
+}

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -4,15 +4,15 @@
 package tun
 
 import (
-	"os/exec"
-	"net"
 	"fmt"
+	"net"
+	"os/exec"
 
 	"github.com/songgao/water"
 )
 
 // New creates and returns a new TUN interface for the application.
-func New(name string, address string) (result *water.Interface, err error) {
+func New(name, address string) (result *water.Interface, err error) {
 	// TUN on Windows requires address and network to be set on device creation stage
 	// We also set network to 0.0.0.0/0 so we able to reach networks behind the node
 	// https://github.com/songgao/water/blob/master/params_windows.go
@@ -23,7 +23,7 @@ func New(name string, address string) (result *water.Interface, err error) {
 	}
 	network := net.IPNet{
 		IP:   ip,
-		Mask: net.IPv4Mask(0,0,0,0),
+		Mask: net.IPv4Mask(0, 0, 0, 0),
 	}
 	// Setup TUN Config
 	cfg := water.Config{

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+// +build windows
+
+package tun
+
+import (
+	"os/exec"
+	"net"
+	"fmt"
+
+	"github.com/songgao/water"
+)
+
+// New creates and returns a new TUN interface for the application.
+func New(name string, address string) (result *water.Interface, err error) {
+	// TUN on Windows requires address and network to be set on device creation stage
+	// We also set network to 0.0.0.0/0 so we able to reach networks behind the node
+	// https://github.com/songgao/water/blob/master/params_windows.go
+	// https://gitlab.com/openconnect/openconnect/-/blob/master/tun-win32.c
+	ip, _, err := net.ParseCIDR(address)
+	if err != nil {
+		return nil, err
+	}
+	network := net.IPNet{
+		IP:   ip,
+		Mask: net.IPv4Mask(0,0,0,0),
+	}
+	// Setup TUN Config
+	cfg := water.Config{
+		DeviceType: water.TUN,
+		PlatformSpecificParams: water.PlatformSpecificParams{
+			ComponentID:   "tap0901",
+			InterfaceName: name,
+			Network:       network.String(),
+		},
+	}
+	// Create TUN Interface
+	result, err = water.New(cfg)
+	return
+}
+
+// SetMTU sets the Maximum Tansmission Unit Size for a
+// Packet on the interface.
+func SetMTU(name string, mtu int) (err error) {
+	return netsh("interface", "ipv4", "set", "subinterface", name, "mtu=", fmt.Sprintf("%d", mtu))
+}
+
+// SetAddress sets the interface's known address and subnet.
+func SetAddress(name string, address string) (err error) {
+	return netsh("interface", "ip", "set", "address", "name=", name, "static", address)
+}
+
+// Up brings up an interface to allow it to start accepting connections.
+func Up(name string) (err error) {
+	return
+}
+
+// Down brings down an interface stopping active connections.
+func Down(name string) (err error) {
+	return
+}
+
+// Delete removes a TUN device from the host.
+func Delete(name string) (err error) {
+	return
+}
+
+func netsh(args ...string) (err error) {
+	cmd := exec.Command("netsh", args...)
+	err = cmd.Run()
+	return
+}


### PR DESCRIPTION
Bump Go version from 1.16 to 1.17, on the `go.mod` file.