### PR TITLE
Improve Performance by Reusing Libp2p Streams

### DIFF
--- a/cli/down.go
+++ b/cli/down.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/DataDrake/cli-ng/v2/cmd"
 	"github.com/hyprspace/hyprspace/tun"
@@ -26,8 +29,34 @@ func DownRun(r *cmd.Root, c *cmd.Sub) {
 	// Parse Command Args
 	args := c.Args.(*DownArgs)
 
-	err := tun.Delete(args.InterfaceName)
+	// Parse Global Config Flag for Custom Config Path
+	configPath := r.Flags.(*GlobalFlags).Config
+	if configPath == "" {
+		configPath = "/etc/hyprspace/" + args.InterfaceName + ".yaml"
+	}
+
+	// Read lock from file system to stop process.
+	lockPath := filepath.Join(filepath.Dir(configPath), args.InterfaceName+".lock")
+	out, err := os.ReadFile(lockPath)
 	checkErr(err)
+
+	pid, err := strconv.Atoi(string(out))
+	checkErr(err)
+
+	process, err := os.FindProcess(pid)
+	checkErr(err)
+
+	err0 := process.Signal(os.Interrupt)
+
+	err1 := tun.Delete(args.InterfaceName)
+
+	// Different types of systems may need the tun devices destroyed first or
+	// the process to exit first don't worry as long as one of these two has
+	// suceeded.
+	if err0 != nil && err1 != nil {
+		checkErr(err0)
+		checkErr(err1)
+	}
 
 	fmt.Println("[+] deleted hyprspace " + args.InterfaceName + " daemon")
 }

--- a/cli/down.go
+++ b/cli/down.go
@@ -26,7 +26,8 @@ func DownRun(r *cmd.Root, c *cmd.Sub) {
 	// Parse Command Args
 	args := c.Args.(*DownArgs)
 
-	fmt.Println("[+] ip link delete dev " + args.InterfaceName)
 	err := tun.Delete(args.InterfaceName)
 	checkErr(err)
+
+	fmt.Println("[+] deleted hyprspace " + args.InterfaceName + " daemon")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 // Config is the main Configuration Struct for Hyprspace.
 type Config struct {
+	Path      string          `yaml:"path,omitempty"`
 	Interface Interface       `yaml:"interface"`
 	Peers     map[string]Peer `yaml:"peers"`
 }
@@ -27,12 +28,12 @@ type Peer struct {
 }
 
 // Read initializes a config from a file.
-func Read(path string) (result Config, err error) {
+func Read(path string) (*Config, error) {
 	in, err := os.ReadFile(path)
 	if err != nil {
-		return
+		return nil, err
 	}
-	result = Config{
+	result := Config{
 		Interface: Interface{
 			Name:       "hs0",
 			ListenPort: 8001,
@@ -41,6 +42,14 @@ func Read(path string) (result Config, err error) {
 			PrivateKey: "",
 		},
 	}
+
+	// Read in config settings from file.
 	err = yaml.Unmarshal(in, &result)
-	return
+	if err != nil {
+		return nil, err
+	}
+
+	// Overwrite path of config to input.
+	result.Path = path
+	return &result, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/libp2p/go-libp2p-quic-transport v0.12.0
 	github.com/libp2p/go-tcp-transport v0.2.8
 	github.com/multiformats/go-multiaddr v0.3.3
-	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/vishvananda/netlink v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/libp2p/go-libp2p-quic-transport v0.12.0
 	github.com/libp2p/go-tcp-transport v0.2.8
 	github.com/multiformats/go-multiaddr v0.3.3
+	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091 h1:1zN6ImoqhSJhN8hGXFaJlSC8msLmIbX8bFqOfWLKw0w=
-github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091/go.mod h1:N20Z5Y8oye9a7HmytmZ+tr8Q2vlP0tAHP13kTHzwvQY=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8/go.mod h1:P5HUIBuIWKbyjl083/loAegFkfbFNx5i2qEP4CNbm7E=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/go.sum
+++ b/go.sum
@@ -838,6 +838,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091 h1:1zN6ImoqhSJhN8hGXFaJlSC8msLmIbX8bFqOfWLKw0w=
+github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091/go.mod h1:N20Z5Y8oye9a7HmytmZ+tr8Q2vlP0tAHP13kTHzwvQY=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8/go.mod h1:P5HUIBuIWKbyjl083/loAegFkfbFNx5i2qEP4CNbm7E=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=


### PR DESCRIPTION
- Added support for libp2p stream reuse! This significantly reduces hyprspace CPU usage and improves performance to >300Mbps in my testing over a 1Gbps local connection. (Note: all peers must be updated to the new standard of communication to reuse streams.)
- Improved network interface creation and removal with the addition of interface locks. (This better supports MacOS where devices cannot be deleted until the application is stopped.)