### PR TITLE
Each peer creates a goroutine to discover

### DIFF
--- a/p2p/discover.go
+++ b/p2p/discover.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/host"
@@ -11,7 +12,7 @@ import (
 )
 
 // Discover starts up a DHT based discovery system finding and adding nodes with the same rendezvous string.
-func Discover(ctx context.Context, h host.Host, dht *dht.IpfsDHT, peerTable map[string]peer.ID) {
+func Discover(ctx context.Context, h host.Host, dht *dht.IpfsDHT, ip string, id peer.ID) {
 	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
 
@@ -20,17 +21,19 @@ func Discover(ctx context.Context, h host.Host, dht *dht.IpfsDHT, peerTable map[
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for _, id := range peerTable {
-				if h.Network().Connectedness(id) != network.Connected {
-					addrs, err := dht.FindPeer(ctx, id)
-					if err != nil {
-						continue
-					}
-					_, err = h.Network().DialPeer(ctx, addrs.ID)
-					if err != nil {
-						continue
-					}
+			if h.Network().Connectedness(id) != network.Connected {
+				addr, err := dht.FindPeer(ctx, id)
+				if err != nil {
+					continue
 				}
+				id = addr.ID
+
+				stream, err := h.NewStream(ctx, id, Protocol)
+				if err != nil {
+					continue
+				}
+				fmt.Printf("[+] Connection to %s Successful. Network Ready.\n", ip)
+				_ = stream.Close()
 			}
 		}
 	}


### PR DESCRIPTION
FindPeer takes more time to search, and using for loop will lead to longer search time